### PR TITLE
Update drupal-driver and drupal-extension

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,8 +13,8 @@
     }
   ],
   "require": {
-    "drupal/drupal-extension": "~3.3.0",
-    "drupal/drupal-driver": "~1.2.0",
+    "drupal/drupal-extension": "~3.4",
+    "drupal/drupal-driver": "~1.4",
     "webmozart/assert": "^1.3"
   },
   "require-dev": {


### PR DESCRIPTION
We should use updated versions of drupal driver and drupal extension.
Updating dependencies to see if tests pass.