### PR TITLE
Update drupal driver

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,8 +13,8 @@
     }
   ],
   "require": {
-    "drupal/drupal-extension": "~3.3.0",
-    "drupal/drupal-driver": "~1.2.0",
+    "drupal/drupal-extension": "~3.4",
+    "drupal/drupal-driver": "~1.4",
     "webmozart/assert": "^1.3"
   },
   "require-dev": {

--- a/src/Driver/Cores/CoreInterface.php
+++ b/src/Driver/Cores/CoreInterface.php
@@ -95,17 +95,6 @@ interface CoreInterface extends OriginalCoreInterface {
   public function entityLoad($entity_type, $entity_id);
 
   /**
-   * Deletes an entity permanently.
-   *
-   * @param object $entity
-   *   The drupal entity, appropriately typed.
-   *
-   * @throws \Exception
-   *   In case of failures an exception is thrown.
-   */
-  public function entityDelete($entity);
-
-  /**
    * Add a translation for an entity.
    *
    * @param object $entity

--- a/src/Driver/Cores/Drupal8.php
+++ b/src/Driver/Cores/Drupal8.php
@@ -265,7 +265,7 @@ class Drupal8 extends OriginalDrupal8 implements CoreInterface {
   /**
    * {@inheritdoc}
    */
-  public function entityDelete($entity) {
+  public function entityDelete($entity_type, $entity) {
     $entity->delete();
   }
 


### PR DESCRIPTION
Hi. 

I have a project where I use a library which requires drupal-extension 3.4 and I want to use also your extension.

I forked the project and continued work from update-drupal-driver branch. The only thing that was breaking is the method  entityDelete which now exists in original core interface.

Could you review this to merge this changes on main branch?

Thanks!

