### PR TITLE
Screenshot context improvements.

### DIFF
--- a/src/DrupalExtension/Context/ScreenShotContext.php
+++ b/src/DrupalExtension/Context/ScreenShotContext.php
@@ -64,6 +64,7 @@ class ScreenShotContext extends RawMinkContext {
         if ($context->getMink()->isSessionStarted()) {
           try {
             $context->assertNotWarningMessage('Notice:');
+            $context->assertNotErrorVisible('Notice:');
           }
           catch (\Exception $e) {
             // Use the step test in the filename.

--- a/src/DrupalExtension/Context/ScreenShotContext.php
+++ b/src/DrupalExtension/Context/ScreenShotContext.php
@@ -96,7 +96,7 @@ class ScreenShotContext extends RawMinkContext {
    * @AfterStep
    */
   public function takeScreenshotAfterFailedStep(AfterStepScope $event) {
-    if ($event->getTestResult()->isPassed()) {
+    if ($event->getTestResult()->getResultCode() !== TestResult::FAILED) {
       // Not a failed step.
       return;
     }

--- a/src/DrupalExtension/Context/ScreenShotContext.php
+++ b/src/DrupalExtension/Context/ScreenShotContext.php
@@ -6,6 +6,7 @@ use Behat\Mink\Driver\Selenium2Driver;
 use Behat\Behat\Context\Environment\InitializedContextEnvironment;
 use Behat\Behat\Hook\Scope\AfterStepScope;
 use Behat\Mink\Exception\DriverException;
+use Behat\Testwork\Tester\Result\TestResult;
 
 /**
  * Class ScreenShotContext.
@@ -15,12 +16,22 @@ use Behat\Mink\Exception\DriverException;
 class ScreenShotContext extends RawMinkContext {
 
   /**
+   * Get screenshots path.
+   *
+   * @return string
+   *   Path to screenshots.
+   */
+  public function getScreenshotsPath() {
+    return sys_get_temp_dir();
+  }
+
+  /**
    * Save screenshot with a specific name.
    *
    * @Then (I )take a screenshot :name
    */
   public function takeScreenshot($name = NULL) {
-    $file_name = sys_get_temp_dir() . DIRECTORY_SEPARATOR . $name;
+    $file_name = $this->getScreenshotsPath() . DIRECTORY_SEPARATOR . $name;
     $message = "Screenshot created in @file_name";
     $this->createScreenshot($file_name, $message, FALSE);
   }
@@ -31,7 +42,7 @@ class ScreenShotContext extends RawMinkContext {
    * @Then (I )take a screenshot
    */
   public function takeScreenshotUnnamed() {
-    $file_name = sys_get_temp_dir() . DIRECTORY_SEPARATOR . 'behat-screenshot';
+    $file_name = $this->getScreenshotsPath() . DIRECTORY_SEPARATOR . 'behat-screenshot';
     $message = "Screenshot created in @file_name";
     $this->createScreenshot($file_name, $message);
   }
@@ -65,7 +76,7 @@ class ScreenShotContext extends RawMinkContext {
               $file_name = preg_replace('![^0-9A-Za-z_.-]!', '', $file_name);
             }
             $file_name = substr($file_name, 0, 30);
-            $file_name = sys_get_temp_dir() . DIRECTORY_SEPARATOR . 'behat-notice__' . $file_name;
+            $file_name = $this->getScreenshotsPath() . DIRECTORY_SEPARATOR . 'behat-notice__' . $file_name;
             $message = "Screenshot for behat notice in step created in @file_name";
             $this->createScreenshot($file_name, $message);
             // We don't throw $e any more because we don't fail on the notice.
@@ -98,7 +109,7 @@ class ScreenShotContext extends RawMinkContext {
         $file_name = preg_replace('![^0-9A-Za-z_.-]!', '', $file_name);
       }
       $file_name = substr($file_name, 0, 30);
-      $file_name = sys_get_temp_dir() . DIRECTORY_SEPARATOR . 'behat-failed__' . $file_name;
+      $file_name = $this->getScreenshotsPath() . DIRECTORY_SEPARATOR . 'behat-failed__' . ' - ' . $event->getFeature()->getFile() . '-' . $file_name;
       $message = "Screenshot for failed step created in @file_name";
       $this->createScreenshot($file_name, $message);
     }

--- a/src/DrupalExtension/Context/ScreenShotContext.php
+++ b/src/DrupalExtension/Context/ScreenShotContext.php
@@ -145,8 +145,10 @@ class ScreenShotContext extends RawMinkContext {
       file_put_contents($file_name, $html_data);
     }
     if ($message) {
-      print strtr($message, ['@file_name' => $file_name]);
+      print strtr($message, ['@file_name' => $file_name]) . "\n";
     }
+
+    return $file_name;
   }
 
 }

--- a/src/DrupalExtension/Context/ScreenShotContext.php
+++ b/src/DrupalExtension/Context/ScreenShotContext.php
@@ -112,11 +112,24 @@ class ScreenShotContext extends RawMinkContext {
       $file_name = substr($file_name, 0, 30);
       $file_name = $this->getScreenshotsPath() . DIRECTORY_SEPARATOR . 'behat-failed__' . ' - ' . $event->getFeature()->getFile() . '-' . $file_name;
       $message = "Screenshot for failed step created in @file_name";
-      $this->createScreenshot($file_name, $message);
+      $this->createScreenshotsForErrors($file_name, $message, $event->getTestResult());
     }
     catch (DriverException $e) {
-
     }
+  }
+
+  /**
+   * Create screenshots for errors.
+   *
+   * @param string $file_name
+   *   File name where the error will be saved.
+   * @param string $message
+   *   Error message.
+   * @param \Behat\Testwork\Tester\Result\TestResult $result
+   *   Test result.
+   */
+  public function createScreenshotsForErrors($file_name, $message, TestResult $result) {
+    $this->createScreenshot($file_name, $message);
   }
 
   /**


### PR DESCRIPTION
Hi.

Using the ScreenshotContext I did some changes that maybe you want to have in your repository:

- Obtain screenshots dir (/tmp) from a method. This allows classes which extend it to implement their own screenshots dir.
- When taking screenshots for php notices, also take screenshots for warnings as it could be useful.
- When taking screenshot after failed step, check the step has failed by this condition:
`if ($event->getTestResult()->getResultCode() !== TestResult::FAILED) {`
Checking only the test has not passed would make an screenshot also a step is pending, not only when it fails.
- Allow override way to take screenshots when a step has failed. This is useful for classes which extends ScreenshotContext.

Could this changes be good to apply in the main repository?
Thanks!


