### PR TITLE
Error on afterScenario entityDelete using MenuContext.

### DIFF
--- a/src/DrupalExtension/Context/MenuContext.php
+++ b/src/DrupalExtension/Context/MenuContext.php
@@ -91,7 +91,7 @@ class MenuContext extends RawDrupalContext {
   public function deleteMenuLinks(AfterScenarioScope $event) {
     if ($this->menuLinks) {
       foreach ($this->menuLinks as $menu_link) {
-        $this->getCore()->entityDelete($menu_link);
+        $this->getCore()->entityDelete($menu_link->getEntityTypeId(), $menu_link);
       }
 
       $this->getCore()->clearMenuCache();


### PR DESCRIPTION
Using the step `Given the following "MENU_NAME" menu structure for content` we get the following error message after running the behat tests.

Type error: Too few arguments to function NuvoleWeb\Drupal\Driver\Cores\Drupal8::entityDelete(), 1 passed in /var/www/html/vendor/nuvoleweb/drupal-behat/src/DrupalExtension/Context/MenuContext.php on line 94 and exactly 2 expected (Behat\Testwork\Call\Exception\FatalThrowableError)                                                     
  │
  └─ @AfterScenario

This PR tries to fix it