### PR TITLE
Assert session has started before resizing browser.

### DIFF
--- a/src/DrupalExtension/Context/ResponsiveContext.php
+++ b/src/DrupalExtension/Context/ResponsiveContext.php
@@ -44,6 +44,18 @@ class ResponsiveContext extends RawMinkContext {
   }
 
   /**
+   * {@inheritDoc}
+   */
+  public function getSession($name = null)
+  {
+    $session = parent::getSession($name);
+    if (!$session->isStarted()) {
+      $session->start();
+    }
+    return $session;
+  }
+
+  /**
    * Get device resolution.
    *
    * @param string $name


### PR DESCRIPTION
Since behat/mink 1.7 the browser's session starts only after visiting a page.
But in the case of resizing the window, there are use cases that requires  to start the session before. It's better to resize the window before going to a specific page to ensure the styles are set up correctly.

This PR overrides the getSession method to ensure the session is always started, before executing any method of the responsive context.

Please review, thanks!