### PR TITLE
Declare services as public.

### DIFF
--- a/services.yml
+++ b/services.yml
@@ -12,13 +12,16 @@ parameters:
   drupal.behat.context_initializer.service_container.class: NuvoleWeb\Drupal\DrupalExtension\Context\Initializer\ServiceContainerInitializer
 
 services:
+  _defaults:
+    public: true
+
   drupal.behat.component.resolution:
-    class: %drupal.behat.component.resolution.class%
+    class: '%drupal.behat.component.resolution.class%'
   drupal.behat.component.py_string_yaml_parser:
-    class: %drupal.behat.component.py_string_yaml_parser.class%
+    class: '%drupal.behat.component.py_string_yaml_parser.class%'
   drupal.behat.component.random:
-    class: %drupal.behat.component.random.class%
+    class: '%drupal.behat.component.random.class%'
   drupal.behat.context_initializer.service_container:
-    class: %drupal.behat.context_initializer.service_container.class%
+    class: '%drupal.behat.context_initializer.service_container.class%'
     tags:
       -  { name: context.initializer }


### PR DESCRIPTION
The last version of Drupal extension requires the services to be public, otherwise it won't be used. This pull request declare any service used in this library as public to satisfy this requirement.