### PR TITLE
Fixes PHP TypeError when asserting for a non-visible field

### DIFF
--- a/src/DrupalExtension/Context/VisibilityContext.php
+++ b/src/DrupalExtension/Context/VisibilityContext.php
@@ -69,13 +69,13 @@ class VisibilityContext extends RawMinkContext {
    *
    * @param string $element
    *   Element selector or a string that describes it.
-   * @param \Behat\Mink\Element\NodeElement $node
+   * @param \Behat\Mink\Element\NodeElement|null $node
    *   Node representing the element above, if any.
    *
    * @throws \Behat\Mink\Exception\ExpectationException
    *    Throws exception if element not found.
    */
-  protected function assertElementVisible($element, NodeElement $node) {
+  protected function assertElementVisible($element, ?NodeElement $node) {
     try {
       if ($node && !$node->isVisible()) {
         throw new ExpectationException(sprintf("The element '%s' is not present on the page %s", $element, $this->getSession()->getCurrentUrl()), $this->getSession());
@@ -96,13 +96,13 @@ class VisibilityContext extends RawMinkContext {
    *
    * @param string $element
    *   Element selector or a string that describes it.
-   * @param \Behat\Mink\Element\NodeElement $node
+   * @param \Behat\Mink\Element\NodeElement|null $node
    *   Node representing the element above, if any.
    *
    * @throws \Behat\Mink\Exception\ExpectationException
    *    Throws exception if element is found.
    */
-  protected function assertElementNotVisible($element, NodeElement $node) {
+  protected function assertElementNotVisible($element, ?NodeElement $node) {
     try {
       if ($node && $node->isVisible()) {
         throw new ExpectationException(sprintf("The field '%s' was present on the page %s and was not supposed to be", $element, $this->getSession()->getCurrentUrl()), $this->getSession());


### PR DESCRIPTION
When asserting for a non-visible field, there is a type error:
```
Type error: NuvoleWeb\Drupal\DrupalExtension\Context\VisibilityContext::assertElementNotVisible(): Argument #2 ($node) must be of type Behat\Mink\Element\NodeElement, null given, called in vendor/nuvoleweb/drupal-behat/src/DrupalExtension/Context/VisibilityContext.php on line 64
```

Ironically, this TypeError indicates success—the element could not be found so the argument is null. But the TypeError causes the tests to fail. This PR adjusts the type arguments to allow `NULL`.